### PR TITLE
PP9-11287 - ContentPortal: Items in filters not loaded when switching channels

### DIFF
--- a/Picturepark.ContentPortal.Demo/Picturepark.ContentPortal.Demo/ClientApp/src/app/components/content-manager/content-manager.component.ts
+++ b/Picturepark.ContentPortal.Demo/Picturepark.ContentPortal.Demo/ClientApp/src/app/components/content-manager/content-manager.component.ts
@@ -158,13 +158,19 @@ export class ContentManagerComponent extends PageBase implements OnInit, OnChang
   }
 
   public changeChannel(channel: Channel) {
-    // Clears aggregation Filters if there is a channelChange
     if (this.channel?.id !== channel.id) {
-      this.facade.patchRequestState({ aggregationFilters: [], channelId: channel.id });
-    }
+      // Clears aggregation Filters, resets the aggregators sets the channel id
+      this.facade.patchRequestState({
+        aggregationFilters: [],
+        aggregators: channel.aggregations,
+        channelId: channel.id,
+      });
 
-    this.channel = channel;
-    this.emitParamsUpdate(this.queryParams);
+      const params = this.queryParams;
+      delete params.filter;
+      this.channel = channel;
+      this.emitParamsUpdate(params);
+    }
   }
 
   public changeSearchQuery(query: string) {


### PR DESCRIPTION
 - Applied aggregation filters are properly cleared when changing channel